### PR TITLE
changed to override p override in the footnotes

### DIFF
--- a/_sass/_06_typography.scss
+++ b/_sass/_06_typography.scss
@@ -330,10 +330,9 @@ mark {
 .footnotes ol { 
     font-size: $font-size-small;
 }
-.footnotes ol * {
-    font-size: 1em;
+.footnotes p {
+    font-size: inherit;
 }
-
 
 
 /* Icon Font


### PR DESCRIPTION
It appears that the reason the footer em size wasn't working is that the p tag uses a 1rem font size which overrides any parent tag's declarations.  I directed p children of the footer  block to inherit their parent's size.