### PR TITLE
Fixing fouc

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,28 +8,19 @@
     <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="/feed.xml" />
 	<script src="{{ site.url }}{{ site.baseurl }}/assets/js/modernizr.min.js"></script>	
 
-    <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic%7cVolkhov' rel='stylesheet' type='text/css'>
-<!--    
+  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js"></script>
   <script>
-    WebFontConfig = {
-      google: { families: [ 'Lato:400,700,400italic:latin', 'Volkhov::latin' ] }
-    };
-
-    (function() {
-      var wf = document.createElement('script');
-      wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
-                '://ajax.googleapis.com/ajax/libs/webfont/1.5.6/webfont.js';
-      wf.type = 'text/javascript';
-      wf.async = 'true';
-      var s = document.getElementsByTagName('script')[0];
-      s.parentNode.insertBefore(wf, s);
-    })();
+    WebFont.load({
+      google: {
+        families: [ 'Lato:400,700,400italic:latin', 'Volkhov::latin' ] 
+      }
+    });
   </script>
 
   <noscript>
-    <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic%7cVolkhov' rel='stylesheet' type='text/css'>
+    <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic|Volkhov' rel='stylesheet' type='text/css'>
   </noscript>
--->
+
   {% if site.google_site_verification %}<meta name="google-site-verification" content="{{ site.google_site_verification}}" />{% endif %}
 	{% if site.bing_webmastertools_id %}<meta name="msvalidate.01" content="{{ site.bing_webmastertools_id }}" />{% endif %}
 	{% if page.meta_description %}<meta name="description" content="{{ page.meta_description | strip_html | escape }}"/>{% elsif page.teaser %}<meta name="description" content="{{ page.teaser | strip_html | escape }}"/>{% elsif site.description %}<meta name="description" content="{{ site.description | strip_html | escape }}"/>{% endif %}

--- a/_sass/_06_typography.scss
+++ b/_sass/_06_typography.scss
@@ -330,10 +330,9 @@ mark {
 .footnotes ol { 
     font-size: $font-size-small;
 }
-.footnotes ol * {
-    font-size: 1em;
+.footnotes p {
+    font-size: inherit;
 }
-
 
 
 /* Icon Font


### PR DESCRIPTION
Added code to use Google's Web Font loader (https://github.com/typekit/webfontloader). in a synchronous manner so it continues to avoid the Flash of Unstyled Content.

Since the Feeling Reponsive site doesn't seem to use any of the web font loader's features, I'm not sure this is a functional improvement from simply using the link to fonts.googleapis.com.